### PR TITLE
Upgrade TypeScript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@types/express": "^4.17.1",
         "nodemon": "^2.0.15",
         "ts-node": "^8.1.0",
-        "typescript": "^3.4.5"
+        "typescript": "^3.9.10"
       },
       "engines": {
         "node": "12.14.1"
@@ -2618,9 +2618,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz",
-      "integrity": "sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==",
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -4880,9 +4880,9 @@
       }
     },
     "typescript": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz",
-      "integrity": "sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==",
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
       "dev": true
     },
     "undefsafe": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@types/express": "^4.17.1",
     "nodemon": "^2.0.15",
     "ts-node": "^8.1.0",
-    "typescript": "^3.4.5"
+    "typescript": "^3.9.10"
   },
   "dependencies": {
     "@colyseus/monitor": "^0.11.0",


### PR DESCRIPTION
This PR upgrades `typescript` from `v3.4.5` to `v3.9.10`. The previous version was raising error `TS1005` during compilement.